### PR TITLE
Testing scaffold, automated with Gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,57 @@
+var gulp = require('gulp');
+var del = require('del');
+var jshint = require('gulp-jshint');
+var concat = require('gulp-concat');
+var uglify = require('gulp-uglify');
+var notify = require('gulp-notify');
+var rename = require('gulp-rename');
+var karma = require('karma').server;
+// var watch = require('gulp-watch');
+
+var handleError = function(err) {
+  console.log('ERROR MSG:', error.toString());
+  this.emit('end');
+};
+
+// Default, runs on 'gulp' command
+gulp.task('default', ['clean', 'test'], function() {
+  gulp.start('scripts');
+});
+
+// Jshint, concats, uglifies scripts into dist
+gulp.task('scripts', function() {
+  return gulp.src('src/scripts/*.js')
+    .pipe(jshint())
+    .pipe(jshint.reporter('default'))
+    .pipe(concat('main.js'))
+    .pipe(gulp.dest('dist/assets/js'))
+    .pipe(rename({suffix: '.min'}))
+    .pipe(uglify({
+      beautify: true
+    }))
+    .on('error', handleError)
+    .pipe(gulp.dest('dist/assets/js'))
+    .pipe(notify({message: 'Scripts task complete'}));
+});
+
+// Runs Karma tests
+gulp.task('test', function(done) {
+  karma.start({
+    configFile: __dirname + '/karma.conf.js',
+    singleRun: true
+  }, function() {
+    done();
+  });
+});
+
+// Deletes what's in dist
+gulp.task('clean', function(cb) {
+  del(['dist/assets/js'], cb)
+});
+
+gulp.task('watch', function() {
+  // Create LiveReload server
+  // livereload.listen();
+  // gulp.watch(['dist/**']).on('change', livereload.changed);
+  gulp.watch('src/scripts/*.js', ['scripts']);
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,10 +6,20 @@ var uglify = require('gulp-uglify');
 var notify = require('gulp-notify');
 var rename = require('gulp-rename');
 var karma = require('karma').server;
+var eventStream = require('event-stream');
+var order = require('gulp-order');
 // var watch = require('gulp-watch');
 
+var paths = {
+  src: {
+    main: 'client/src/*.js',
+    components: 'client/src/*/*.js'
+  },
+  karmaConf: __dirname + '/karma.conf.js'
+};
+
 var handleError = function(err) {
-  console.log('ERROR MSG:', error.toString());
+  console.log('ERROR MSG:', err.toString());
   this.emit('end');
 };
 
@@ -20,24 +30,35 @@ gulp.task('default', ['clean', 'test'], function() {
 
 // Jshint, concats, uglifies scripts into dist
 gulp.task('scripts', function() {
-  return gulp.src('src/scripts/*.js')
+  var appFiles = gulp.src(paths.src.main)
     .pipe(jshint())
     .pipe(jshint.reporter('default'))
-    .pipe(concat('main.js'))
-    .pipe(gulp.dest('dist/assets/js'))
-    .pipe(rename({suffix: '.min'}))
-    .pipe(uglify({
-      beautify: true
-    }))
     .on('error', handleError)
-    .pipe(gulp.dest('dist/assets/js'))
-    .pipe(notify({message: 'Scripts task complete'}));
+    .pipe(concat('app.temp.js'));
+
+  var componentFiles = gulp.src(paths.src.components)
+    .pipe(jshint())
+    .pipe(jshint.reporter('default'))
+    .on('error', handleError)
+    .pipe(concat('components.temp.js'));
+
+  return eventStream.concat(appFiles, componentFiles)
+    .pipe(order([
+      'app.temp.js',
+      'components.temp.js'
+    ]))
+    .pipe(concat('main.js'))
+    .pipe(gulp.dest('client/dist/assets/js'))
+    .pipe(rename({suffix: '.min'}))
+    .pipe(uglify())
+    .pipe(gulp.dest('client/dist/assets/js'))
+    .pipe(notify({message: 'Tests and scripts task complete'}));
 });
 
 // Runs Karma tests
 gulp.task('test', function(done) {
   karma.start({
-    configFile: __dirname + '/karma.conf.js',
+    configFile: paths.karmaConf,
     singleRun: true
   }, function() {
     done();
@@ -49,9 +70,9 @@ gulp.task('clean', function(cb) {
   del(['dist/assets/js'], cb)
 });
 
-gulp.task('watch', function() {
-  // Create LiveReload server
-  // livereload.listen();
-  // gulp.watch(['dist/**']).on('change', livereload.changed);
-  gulp.watch('src/scripts/*.js', ['scripts']);
-});
+// gulp.task('watch', function() {
+//   // Create LiveReload server
+//   // livereload.listen();
+//   // gulp.watch(['dist/**']).on('change', livereload.changed);
+//   gulp.watch('src/scripts/*.js', ['scripts']);
+// });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,67 @@
+// Karma configuration
+// Generated on Fri Feb 13 2015 18:39:09 GMT-0800 (PST)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['requirejs', 'mocha', 'chai'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'test-main.js',
+      {pattern: 'client/src/*.js', included: false},
+      {pattern: 'test/**/*.spec.js', included: false}
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome', 'PhantomJS'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  });
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       'test-main.js',
-      {pattern: 'client/src/*.js', included: false},
+      {pattern: 'client/src/**/*.js', included: false},
       {pattern: 'test/**/*.spec.js', included: false}
     ],
 
@@ -57,7 +57,8 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome', 'PhantomJS'],
+    // browsers: ['Chrome', 'PhantomJS'],
+    browsers: ['PhantomJS'],
 
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -19,11 +19,13 @@
   "devDependencies": {
     "chai": "^2.0.0",
     "del": "^1.1.1",
+    "event-stream": "^3.2.2",
     "gulp": "^3.8.11",
     "gulp-concat": "^2.4.3",
     "gulp-jshint": "^1.9.2",
     "gulp-minify-css": "^0.4.5",
     "gulp-notify": "^2.2.0",
+    "gulp-order": "^1.1.1",
     "gulp-rename": "^1.2.0",
     "gulp-uglify": "^1.1.0",
     "karma": "^0.12.31",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,31 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TroutZen/LenderBee.git"
+    "url": "https://github.com/logicalGoldfish/LenderBee.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/TroutZen/LenderBee/issues"
+    "url": "https://github.com/logicalGoldfish/LenderBee/issues"
   },
-  "homepage": "https://github.com/TroutZen/LenderBee"
+  "homepage": "https://github.com/logicalGoldfish/LenderBee",
+  "devDependencies": {
+    "chai": "^2.0.0",
+    "del": "^1.1.1",
+    "gulp": "^3.8.11",
+    "gulp-concat": "^2.4.3",
+    "gulp-jshint": "^1.9.2",
+    "gulp-minify-css": "^0.4.5",
+    "gulp-notify": "^2.2.0",
+    "gulp-rename": "^1.2.0",
+    "gulp-uglify": "^1.1.0",
+    "karma": "^0.12.31",
+    "karma-chai": "^0.1.0",
+    "karma-chrome-launcher": "^0.1.7",
+    "karma-mocha": "^0.1.10",
+    "karma-phantomjs-launcher": "^0.1.4",
+    "karma-requirejs": "^0.2.2",
+    "mocha": "^2.1.0",
+    "requirejs": "^2.1.16"
+  }
 }

--- a/test-main.js
+++ b/test-main.js
@@ -1,0 +1,24 @@
+var allTestFiles = [];
+var TEST_REGEXP = /(spec|test)\.js$/i;
+
+var pathToModule = function(path) {
+  return path.replace(/^\/base\//, '').replace(/\.js$/, '');
+};
+
+Object.keys(window.__karma__.files).forEach(function(file) {
+  if (TEST_REGEXP.test(file)) {
+    // Normalize paths to RequireJS module names.
+    allTestFiles.push(pathToModule(file));
+  }
+});
+
+require.config({
+  // Karma serves files under /base, which is the basePath from your config file
+  baseUrl: '/base',
+
+  // dynamically load all test files
+  deps: allTestFiles,
+
+  // we have to kickoff jasmine, as it is asynchronous
+  callback: window.__karma__.start
+});

--- a/test/test/testing.spec.js
+++ b/test/test/testing.spec.js
@@ -1,0 +1,17 @@
+// Example of a test
+
+describe("A test suite", function() {
+   beforeEach(function() { 
+     console.log('before it\'s running');
+   });
+   afterEach(function() { 
+     console.log('after it\'s running');
+   });
+   // it('should fail', function() { expect(true).to.be.false; });
+   it('should pass', function() {
+    expect(true).to.be.true;
+   });
+   it('should pass again', function() {
+    expect(true).to.equal(true);
+   })
+});


### PR DESCRIPTION
This closes #2.

I created a dummy test/template under test/test/testing.spec.js. Additional tests can be created using the filepath and format `test/<your component>/<your component>.spec.js`.

Tests can be run from the command line with `gulp test`.

To test and build the dist files, run `gulp`.
