### PR TITLE
Return items with no borrower for getOneByUser

### DIFF
--- a/server/items/controller.js
+++ b/server/items/controller.js
@@ -108,8 +108,8 @@ controller.getOneByUser = function(req, res, next){
       { borrower_id: userId }
     ),
     include: [ 
-      {model: User, as: 'borrower', required: true},
-      {model: User, as: 'lender', required: true},
+      {model: User, as: 'borrower'},
+      {model: User, as: 'lender'},
     ]
   }).
   then(function(items){


### PR DESCRIPTION
Update to issue #306. Pull request #310 did not return items with `null` for borrower_id; this fixes that issue.
